### PR TITLE
Shows missed annihilation soaks in the event view.

### DIFF
--- a/antorus-the-burning-throne/garothi-worldbreaker/abilities.json
+++ b/antorus-the-burning-throne/garothi-worldbreaker/abilities.json
@@ -40,7 +40,7 @@
       "minimum": 3,
       "title": "{[style=\"ability\"] Annihilation} soak missed.",
       "ability": {
-        "id": 22762
+        "id": 244762
       }
     }
   },

--- a/antorus-the-burning-throne/garothi-worldbreaker/abilities.json
+++ b/antorus-the-burning-throne/garothi-worldbreaker/abilities.json
@@ -34,8 +34,8 @@
     "tags": [ "boss", "ability" ],
     "show": true,
     "eventType": "ability",
-    "friendly": false,
-    "title": "{[style=\"ability\"] Annihilation} soak missed.",
+    "friendly": true,
+    "title": "{[style=\"fire\"] Annihilation} soak missed.",
     "filter": {
       "types": [ "damage", "absorb" ],
       "range": 3000,

--- a/antorus-the-burning-throne/garothi-worldbreaker/abilities.json
+++ b/antorus-the-burning-throne/garothi-worldbreaker/abilities.json
@@ -30,12 +30,13 @@
   },
   {
     "id": "MA",
-    "name": "Missed Soaking Annihilation",
+    "name": "Annihilation Soak Missed",
     "tags": [ "boss", "ability" ],
     "show": true,
     "eventType": "ability",
+    "friendly": false,
     "filter": {
-      "type": "cast",
+      "types": [ "damage", "absorb" ],
       "range": 3000,
       "minimum": 3,
       "title": "{[style=\"ability\"] Annihilation} soak missed.",

--- a/antorus-the-burning-throne/garothi-worldbreaker/abilities.json
+++ b/antorus-the-burning-throne/garothi-worldbreaker/abilities.json
@@ -38,7 +38,7 @@
       "type": "cast",
       "range": 3000,
       "minimum": 3,
-      "title": "{[style=\"npc\"] Annihilation} soak missed.",
+      "title": "{[style=\"ability\"] Annihilation} soak missed.",
       "ability": {
         "id": 22762
       }
@@ -154,7 +154,7 @@
     "tags": [ "boss", "ability" ],
     "show": true,
     "eventType": "ability",
-    "title": "{[style=\"ability\"] Annihilator} destroyed",
+    "title": "{[style=\"npc\"] Annihilator} destroyed",
     "filter": {
       "type": "cast",
       "ability": {

--- a/antorus-the-burning-throne/garothi-worldbreaker/abilities.json
+++ b/antorus-the-burning-throne/garothi-worldbreaker/abilities.json
@@ -29,6 +29,22 @@
     }
   },
   {
+    "id": "MA",
+    "name": "Missed Soaking Annihilation",
+    "tags": [ "boss", "ability" ],
+    "show": true,
+    "eventType": "ability",
+    "filter": {
+      "type": "cast",
+      "range": 3000,
+      "minimum": 3,
+      "title": "{[style=\"npc\"] Annihilation} soak missed.",
+      "ability": {
+        "id": 22762
+      }
+    }
+  },
+  {
     "id": "0D",
     "name": "Decimation",
     "tags": [ "boss", "ability" ],

--- a/antorus-the-burning-throne/garothi-worldbreaker/abilities.json
+++ b/antorus-the-burning-throne/garothi-worldbreaker/abilities.json
@@ -35,7 +35,7 @@
     "show": true,
     "eventType": "ability",
     "friendly": true,
-    "title": "{[style=\"fire\"] Annihilation} soak missed.",
+    "title": "{[style=\"fire\"] Annihilation} soak missed",
     "filter": {
       "types": [ "damage", "absorb" ],
       "range": 3000,

--- a/antorus-the-burning-throne/garothi-worldbreaker/abilities.json
+++ b/antorus-the-burning-throne/garothi-worldbreaker/abilities.json
@@ -35,11 +35,11 @@
     "show": true,
     "eventType": "ability",
     "friendly": false,
+    "title": "{[style=\"ability\"] Annihilation} soak missed.",
     "filter": {
       "types": [ "damage", "absorb" ],
       "range": 3000,
       "minimum": 3,
-      "title": "{[style=\"ability\"] Annihilation} soak missed.",
       "ability": {
         "id": 244762
       }

--- a/antorus-the-burning-throne/garothi-worldbreaker/abilities.json
+++ b/antorus-the-burning-throne/garothi-worldbreaker/abilities.json
@@ -154,7 +154,7 @@
     "tags": [ "boss", "ability" ],
     "show": true,
     "eventType": "ability",
-    "title": "{[style=\"npc\"] Annihilator} destroyed",
+    "title": "{[style=\"ability\"] Annihilator} destroyed",
     "filter": {
       "type": "cast",
       "ability": {


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/9600587/39085394-90e1bdba-454f-11e8-9380-552b1602aa0e.png)
